### PR TITLE
Add ability to fetch localized numbers

### DIFF
--- a/src/main/java/net/dean/jraw/models/Comment.java
+++ b/src/main/java/net/dean/jraw/models/Comment.java
@@ -1,9 +1,11 @@
 package net.dean.jraw.models;
 
-import net.dean.jraw.models.meta.JsonProperty;
-import net.dean.jraw.models.meta.Model;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import net.dean.jraw.models.meta.JsonProperty;
+import net.dean.jraw.models.meta.Model;
+
+import java.text.NumberFormat;
 import java.util.Date;
 
 /** Represents a comment on a Submission */
@@ -131,6 +133,15 @@ public class Comment extends PublicContribution {
     @JsonProperty(nullable = true)
     public Integer getReportCount() {
         return data("num_reports", Integer.class);
+    }
+
+    /** Gets the localized amount of times this comment has been reported, or null if the logged in user is not a mod */
+    public String getLocalizedReportCount() {
+        try {
+            return NumberFormat.getInstance().format(getReportCount());
+        } catch (final IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/net/dean/jraw/models/LiveThread.java
+++ b/src/main/java/net/dean/jraw/models/LiveThread.java
@@ -5,6 +5,7 @@ import net.dean.jraw.models.attr.Created;
 import net.dean.jraw.models.meta.JsonProperty;
 import net.dean.jraw.models.meta.Model;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -54,6 +55,15 @@ public final class LiveThread extends RedditObject implements Created {
     @JsonProperty
     public Integer getViewerCount() {
         return data("viewer_count", Integer.class);
+    }
+
+    /** Gets the localized amount of people watching this thread */
+    public String getLocalizedViewerCount() {
+        try {
+            return NumberFormat.getInstance().format(getViewerCount());
+        } catch (final IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /** Checks if the viewer count is "fuzzed". This most often happens when there are less than 100 viewers. */

--- a/src/main/java/net/dean/jraw/models/LoggedInAccount.java
+++ b/src/main/java/net/dean/jraw/models/LoggedInAccount.java
@@ -1,8 +1,11 @@
 package net.dean.jraw.models;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import net.dean.jraw.models.meta.JsonProperty;
 import net.dean.jraw.models.meta.Model;
-import com.fasterxml.jackson.databind.JsonNode;
+
+import java.text.NumberFormat;
 
 /**
  * Represents an account with additional information visible only to the logged-in user.
@@ -36,6 +39,15 @@ public final class LoggedInAccount extends Account {
     @JsonProperty
     public Integer getInboxCount() {
         return data("inbox_count", Integer.class);
+    }
+
+    /** Gets the localized amount of non-moderator mail the user has. */
+    public String getLocalizedInboxCount() {
+        try {
+            return NumberFormat.getInstance().format(getInboxCount());
+        } catch (final IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /** Gets the amount of gold creddits (one month worth of reddit gold) the user has. */

--- a/src/main/java/net/dean/jraw/models/MoreChildren.java
+++ b/src/main/java/net/dean/jraw/models/MoreChildren.java
@@ -5,6 +5,7 @@ import net.dean.jraw.models.meta.JsonProperty;
 import net.dean.jraw.models.meta.Model;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,6 +36,18 @@ public final class MoreChildren extends Thing {
     @JsonProperty
     public Integer getCount() {
         return data("count", Integer.class);
+    }
+
+    /**
+     * Gets the localized amount of IDs in this list
+     * @return The localized amount of IDs in this list
+     */
+    public String getLocalizedCount() {
+        try {
+            return NumberFormat.getInstance().format(getCount());
+        } catch (final IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/net/dean/jraw/models/Submission.java
+++ b/src/main/java/net/dean/jraw/models/Submission.java
@@ -6,6 +6,7 @@ import net.dean.jraw.models.meta.Model;
 import net.dean.jraw.models.meta.SubmissionSerializer;
 import net.dean.jraw.util.JrawUtils;
 
+import java.text.NumberFormat;
 import java.util.Date;
 import java.util.List;
 
@@ -122,6 +123,18 @@ public final class Submission extends PublicContribution {
     @JsonProperty
     public Integer getCommentCount() {
         return data("num_comments", Integer.class);
+    }
+
+    /**
+     * Gets the localized number of comments that belong to this submission. Includes removed comments.
+     * @return Gets the total number of comments that belong to this submission localized for the current locale
+     */
+    public String getLocalizedCommentCount() {
+        try {
+            return NumberFormat.getInstance().format(getCommentCount());
+        } catch (final IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/net/dean/jraw/models/Subreddit.java
+++ b/src/main/java/net/dean/jraw/models/Subreddit.java
@@ -1,9 +1,12 @@
 package net.dean.jraw.models;
 
-import net.dean.jraw.util.Dimension;
+import com.fasterxml.jackson.databind.JsonNode;
+
 import net.dean.jraw.models.meta.JsonProperty;
 import net.dean.jraw.models.meta.Model;
-import com.fasterxml.jackson.databind.JsonNode;
+import net.dean.jraw.util.Dimension;
+
+import java.text.NumberFormat;
 
 /** This class represents a subreddit, such as /r/pics. */
 @Model(kind = Model.Kind.SUBREDDIT)
@@ -89,6 +92,15 @@ public final class Subreddit extends Thing implements Comparable<Subreddit> {
     @JsonProperty
     public Long getSubscriberCount() {
         return data("subscribers", Long.class);
+    }
+
+    /** Gets the localized amount of users subscribed to this subreddit */
+    public String getLocalizedSubscriberCount() {
+        try {
+            return NumberFormat.getInstance().format(getSubscriberCount());
+        } catch (final IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /** Gets the types of submissions allowed to be posted on this subreddit */


### PR DESCRIPTION
Give the consumer of this library the ability to fetch numbers correctly localized using [NumberFormat](https://docs.oracle.com/javase/7/docs/api/java/text/NumberFormat.html). This was driven by attempting to fix this issue in Slide: https://github.com/ccrama/Slide/issues/1771

The consumer of this library could themselves format the raw number but I thought I would try this approach first.
